### PR TITLE
`@next/font` を使う

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -64,20 +64,12 @@ const Layout = (props) => {
         body {
           padding: 0;
           margin: 0;
-          font-family: 'Noto Sans JP', -apple-system, "Segoe UI", "Helvetica Neue",
-            "Hiragino Kaku Gothic ProN", メイリオ, meiryo, sans-serif;
           color: #222;
-          font-size: 16px;
         }
 
         img,
         iframe {
           max-width: 100%;
-        }
-
-        h1, h2, h3, h4, h5, h6 {
-          font-family: Montserrat, -apple-system, "Segoe UI", "Helvetica Neue",
-            "Hiragino Kaku Gothic ProN", メイリオ, meiryo, sans-serif;
         }
 
         /* Prism のコードブロックに影響を与えず <code> にスタイルを追加 */

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -58,33 +58,6 @@ const Layout = (props) => {
           align-items: center;
         }
       `}</style>
-
-      <style jsx global>{`
-        html,
-        body {
-          padding: 0;
-          margin: 0;
-          color: #222;
-        }
-
-        img,
-        iframe {
-          max-width: 100%;
-        }
-
-        /* Prism のコードブロックに影響を与えず <code> にスタイルを追加 */
-        code:not([class]) {
-          font-family: monospace;
-          font-size: 1rem;
-          background-color: #eee;
-          display: inline-block;
-          padding: .2em .4em;
-        }
-
-        * {
-          box-sizing: border-box;
-        }
-      `}</style>
     </div>
   )
 }

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -19,7 +19,7 @@ const Layout = (props) => {
       </header>
 
       <main>
-        {title ? <h1 className="page-title">{title}</h1> : ``}
+        {title ? <h1 className="page-title">{title}</h1> : null}
         <div className="page-main">
           {children}
         </div>

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -14,7 +14,13 @@ const Layout = (props) => {
 
       <header>
         <h1 className="site-title">
-          <Link href="/">{siteTitle}</Link>
+          <Link href="/" style={{
+            // `<style jsx>` ではスタイルをつけられないのでインラインで設定する
+            color: 'inherit',
+            textDecoration: 'none',
+          }}>
+            <span className="site-title-text">{siteTitle}</span>
+          </Link>
         </h1>
       </header>
 
@@ -42,11 +48,6 @@ const Layout = (props) => {
           justify-content: center;
           align-items: center;
           margin: 0 0 4em;
-        }
-
-        .site-title a {
-          color: inherit;
-          text-decoration: none;
         }
 
         footer {

--- a/components/__tests__/__snapshots__/Layout.test.js.snap
+++ b/components/__tests__/__snapshots__/Layout.test.js.snap
@@ -2,23 +2,23 @@
 
 exports[`Layout renders collectly with children 1`] = `
 <div
-  className="jsx-271807279 page"
+  className="jsx-652147177 page"
 >
   <title
-    className="jsx-271807279"
+    className="jsx-652147177"
   >
     サンプルブログ
   </title>
   <link
-    className="jsx-271807279"
+    className="jsx-652147177"
     href="/favicon.ico"
     rel="icon"
   />
   <header
-    className="jsx-271807279"
+    className="jsx-652147177"
   >
     <h1
-      className="jsx-271807279 site-title"
+      className="jsx-652147177 site-title"
     >
       <a
         href="/"
@@ -28,10 +28,10 @@ exports[`Layout renders collectly with children 1`] = `
     </h1>
   </header>
   <main
-    className="jsx-271807279"
+    className="jsx-652147177"
   >
     <div
-      className="jsx-271807279 page-main"
+      className="jsx-652147177 page-main"
     >
       <div>
         <span>
@@ -41,7 +41,7 @@ exports[`Layout renders collectly with children 1`] = `
     </div>
   </main>
   <footer
-    className="jsx-271807279"
+    className="jsx-652147177"
   >
     © 
     サンプルブログ
@@ -51,23 +51,23 @@ exports[`Layout renders collectly with children 1`] = `
 
 exports[`Layout renders collectly with title 1`] = `
 <div
-  className="jsx-271807279 page"
+  className="jsx-652147177 page"
 >
   <title
-    className="jsx-271807279"
+    className="jsx-652147177"
   >
     ページタイトル | サンプルブログ
   </title>
   <link
-    className="jsx-271807279"
+    className="jsx-652147177"
     href="/favicon.ico"
     rel="icon"
   />
   <header
-    className="jsx-271807279"
+    className="jsx-652147177"
   >
     <h1
-      className="jsx-271807279 site-title"
+      className="jsx-652147177 site-title"
     >
       <a
         href="/"
@@ -77,19 +77,19 @@ exports[`Layout renders collectly with title 1`] = `
     </h1>
   </header>
   <main
-    className="jsx-271807279"
+    className="jsx-652147177"
   >
     <h1
-      className="jsx-271807279 page-title"
+      className="jsx-652147177 page-title"
     >
       ページタイトル
     </h1>
     <div
-      className="jsx-271807279 page-main"
+      className="jsx-652147177 page-main"
     />
   </main>
   <footer
-    className="jsx-271807279"
+    className="jsx-652147177"
   >
     © 
     サンプルブログ

--- a/components/__tests__/__snapshots__/Layout.test.js.snap
+++ b/components/__tests__/__snapshots__/Layout.test.js.snap
@@ -2,23 +2,23 @@
 
 exports[`Layout renders collectly with children 1`] = `
 <div
-  className="jsx-4151687426 page"
+  className="jsx-271807279 page"
 >
   <title
-    className="jsx-4151687426"
+    className="jsx-271807279"
   >
     サンプルブログ
   </title>
   <link
-    className="jsx-4151687426"
+    className="jsx-271807279"
     href="/favicon.ico"
     rel="icon"
   />
   <header
-    className="jsx-4151687426"
+    className="jsx-271807279"
   >
     <h1
-      className="jsx-4151687426 site-title"
+      className="jsx-271807279 site-title"
     >
       <a
         href="/"
@@ -28,10 +28,10 @@ exports[`Layout renders collectly with children 1`] = `
     </h1>
   </header>
   <main
-    className="jsx-4151687426"
+    className="jsx-271807279"
   >
     <div
-      className="jsx-4151687426 page-main"
+      className="jsx-271807279 page-main"
     >
       <div>
         <span>
@@ -41,7 +41,7 @@ exports[`Layout renders collectly with children 1`] = `
     </div>
   </main>
   <footer
-    className="jsx-4151687426"
+    className="jsx-271807279"
   >
     © 
     サンプルブログ
@@ -51,23 +51,23 @@ exports[`Layout renders collectly with children 1`] = `
 
 exports[`Layout renders collectly with title 1`] = `
 <div
-  className="jsx-4151687426 page"
+  className="jsx-271807279 page"
 >
   <title
-    className="jsx-4151687426"
+    className="jsx-271807279"
   >
     ページタイトル | サンプルブログ
   </title>
   <link
-    className="jsx-4151687426"
+    className="jsx-271807279"
     href="/favicon.ico"
     rel="icon"
   />
   <header
-    className="jsx-4151687426"
+    className="jsx-271807279"
   >
     <h1
-      className="jsx-4151687426 site-title"
+      className="jsx-271807279 site-title"
     >
       <a
         href="/"
@@ -77,19 +77,19 @@ exports[`Layout renders collectly with title 1`] = `
     </h1>
   </header>
   <main
-    className="jsx-4151687426"
+    className="jsx-271807279"
   >
     <h1
-      className="jsx-4151687426 page-title"
+      className="jsx-271807279 page-title"
     >
       ページタイトル
     </h1>
     <div
-      className="jsx-4151687426 page-main"
+      className="jsx-271807279 page-main"
     />
   </main>
   <footer
-    className="jsx-4151687426"
+    className="jsx-271807279"
   >
     © 
     サンプルブログ

--- a/components/__tests__/__snapshots__/Layout.test.js.snap
+++ b/components/__tests__/__snapshots__/Layout.test.js.snap
@@ -2,36 +2,46 @@
 
 exports[`Layout renders collectly with children 1`] = `
 <div
-  className="jsx-652147177 page"
+  className="jsx-4096959289 page"
 >
   <title
-    className="jsx-652147177"
+    className="jsx-4096959289"
   >
     サンプルブログ
   </title>
   <link
-    className="jsx-652147177"
+    className="jsx-4096959289"
     href="/favicon.ico"
     rel="icon"
   />
   <header
-    className="jsx-652147177"
+    className="jsx-4096959289"
   >
     <h1
-      className="jsx-652147177 site-title"
+      className="jsx-4096959289 site-title"
     >
       <a
         href="/"
+        style={
+          Object {
+            "color": "inherit",
+            "textDecoration": "none",
+          }
+        }
       >
-        サンプルブログ
+        <span
+          className="jsx-4096959289 site-title-text"
+        >
+          サンプルブログ
+        </span>
       </a>
     </h1>
   </header>
   <main
-    className="jsx-652147177"
+    className="jsx-4096959289"
   >
     <div
-      className="jsx-652147177 page-main"
+      className="jsx-4096959289 page-main"
     >
       <div>
         <span>
@@ -41,7 +51,7 @@ exports[`Layout renders collectly with children 1`] = `
     </div>
   </main>
   <footer
-    className="jsx-652147177"
+    className="jsx-4096959289"
   >
     © 
     サンプルブログ
@@ -51,45 +61,55 @@ exports[`Layout renders collectly with children 1`] = `
 
 exports[`Layout renders collectly with title 1`] = `
 <div
-  className="jsx-652147177 page"
+  className="jsx-4096959289 page"
 >
   <title
-    className="jsx-652147177"
+    className="jsx-4096959289"
   >
     ページタイトル | サンプルブログ
   </title>
   <link
-    className="jsx-652147177"
+    className="jsx-4096959289"
     href="/favicon.ico"
     rel="icon"
   />
   <header
-    className="jsx-652147177"
+    className="jsx-4096959289"
   >
     <h1
-      className="jsx-652147177 site-title"
+      className="jsx-4096959289 site-title"
     >
       <a
         href="/"
+        style={
+          Object {
+            "color": "inherit",
+            "textDecoration": "none",
+          }
+        }
       >
-        サンプルブログ
+        <span
+          className="jsx-4096959289 site-title-text"
+        >
+          サンプルブログ
+        </span>
       </a>
     </h1>
   </header>
   <main
-    className="jsx-652147177"
+    className="jsx-4096959289"
   >
     <h1
-      className="jsx-652147177 page-title"
+      className="jsx-4096959289 page-title"
     >
       ページタイトル
     </h1>
     <div
-      className="jsx-652147177 page-main"
+      className="jsx-4096959289 page-main"
     />
   </main>
   <footer
-    className="jsx-652147177"
+    className="jsx-4096959289"
   >
     © 
     サンプルブログ

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nextjs-blog-example-ja",
       "version": "13.0.0",
       "dependencies": {
+        "@next/font": "^13.1.6",
         "gray-matter": "^4.0.2",
         "next": "^13.1.6",
         "react": "^18.2.0",
@@ -3209,6 +3210,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/@next/font": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.1.6.tgz",
+      "integrity": "sha512-AITjmeb1RgX1HKMCiA39ztx2mxeAyxl4ljv2UoSBUGAbFFMg8MO7YAvjHCgFhD39hL7YTbFjol04e/BPBH5RzQ=="
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "13.1.6",
@@ -13310,6 +13316,186 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.1.6.tgz",
+      "integrity": "sha512-F3/6Z8LH/pGlPzR1AcjPFxx35mPqjE5xZcf+IL+KgbW9tMkp7CYi1y7qKrEWU7W4AumxX/8OINnDQWLiwLasLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.1.6.tgz",
+      "integrity": "sha512-cMwQjnB8vrYkWyK/H0Rf2c2pKIH4RGjpKUDvbjVAit6SbwPDpmaijLio0LWFV3/tOnY6kvzbL62lndVA0mkYpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.1.6.tgz",
+      "integrity": "sha512-/uOky5PaZDoaU99ohjtNcDTJ6ks/gZ5ykTQDvNZDjIoCxFe3+t06bxsTPY6tAO6uEAw5f6vVFX5H5KLwhrkZCA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.1.6.tgz",
+      "integrity": "sha512-qaEALZeV7to6weSXk3Br80wtFQ7cFTpos/q+m9XVRFggu+8Ib895XhMWdJBzew6aaOcMvYR6KQ6JmHA2/eMzWw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.1.6.tgz",
+      "integrity": "sha512-OybkbC58A1wJ+JrJSOjGDvZzrVEQA4sprJejGqMwiZyLqhr9Eo8FXF0y6HL+m1CPCpPhXEHz/2xKoYsl16kNqw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.1.6.tgz",
+      "integrity": "sha512-yCH+yDr7/4FDuWv6+GiYrPI9kcTAO3y48UmaIbrKy8ZJpi7RehJe3vIBRUmLrLaNDH3rY1rwoHi471NvR5J5NQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.1.6.tgz",
+      "integrity": "sha512-ECagB8LGX25P9Mrmlc7Q/TQBb9rGScxHbv/kLqqIWs2fIXy6Y/EiBBiM72NTwuXUFCNrWR4sjUPSooVBJJ3ESQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.1.6.tgz",
+      "integrity": "sha512-GT5w2mruk90V/I5g6ScuueE7fqj/d8Bui2qxdw6lFxmuTgMeol5rnzAv4uAoVQgClOUO/MULilzlODg9Ib3Y4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.1.6.tgz",
+      "integrity": "sha512-keFD6KvwOPzmat4TCnlnuxJCQepPN+8j3Nw876FtULxo8005Y9Ghcl7ACcR8GoiKoddAq8gxNBrpjoxjQRHeAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.1.6.tgz",
+      "integrity": "sha512-OwertslIiGQluFvHyRDzBCIB07qJjqabAmINlXUYt7/sY7Q7QPE8xVi5beBxX/rxTGPIbtyIe3faBE6Z2KywhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.1.6.tgz",
+      "integrity": "sha512-g8zowiuP8FxUR9zslPmlju7qYbs2XBtTLVSxVikPtUDQedhcls39uKYLvOOd1JZg0ehyhopobRoH1q+MHlIN/w==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.1.6.tgz",
+      "integrity": "sha512-Ls2OL9hi3YlJKGNdKv8k3X/lLgc3VmLG3a/DeTkAd+lAituJp8ZHmRmm9f9SL84fT3CotlzcgbdaCDfFwFA6bA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@next/font": "^13.1.6",
     "gray-matter": "^4.0.2",
     "next": "^13.1.6",
     "react": "^18.2.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,19 @@
 import Router from 'next/router'
-
+import { Montserrat, Noto_Sans_JP } from '@next/font/google'
 import { GA_TRACKING_ID, pageview } from '../lib/gtag'
+
+/*
+ * Google Fonts を利用する
+ *
+ * - Montserrat
+ * - Noto Sans JP
+ */
+const montserrat = Montserrat({ subsets: ['latin'] })
+const noto_sans_jp = Noto_Sans_JP({
+  weight: ['400', '700'],
+  subsets: ['latin'],
+  fallback: ['-apple-system', 'Segoe UI', 'Helvetica Neue'],
+})
 
 if (GA_TRACKING_ID) {
   Router.events.on('routeChangeComplete', url => pageview(url))
@@ -8,5 +21,21 @@ if (GA_TRACKING_ID) {
 
 // This default export is required in a new `pages/_app.js` file.
 export default function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <style jsx global>{`
+        html {
+          font-family: ${noto_sans_jp.style.fontFamily};
+            "Hiragino Kaku Gothic ProN", メイリオ, meiryo, sans-serif;
+          font-size: 16px;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+          font-family: ${montserrat.style.fontFamily},
+            "Hiragino Kaku Gothic ProN", メイリオ, meiryo, sans-serif;
+        }
+      `}</style>
+      <Component {...pageProps} />
+    </>
+  )
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -24,15 +24,41 @@ export default function MyApp({ Component, pageProps }) {
   return (
     <>
       <style jsx global>{`
+        * {
+          box-sizing: border-box;
+        }
+
         html {
+          padding: 0;
+          margin: 0;
           font-family: ${noto_sans_jp.style.fontFamily};
             "Hiragino Kaku Gothic ProN", メイリオ, meiryo, sans-serif;
           font-size: 16px;
         }
 
+        body {
+          padding: 0;
+          margin: 0;
+          color: #222;
+        }
+
         h1, h2, h3, h4, h5, h6 {
           font-family: ${montserrat.style.fontFamily},
             "Hiragino Kaku Gothic ProN", メイリオ, meiryo, sans-serif;
+        }
+
+        img,
+        iframe {
+          max-width: 100%;
+        }
+
+        /* Prism のコードブロックに影響を与えず <code> にスタイルを追加 */
+        code:not([class]) {
+          font-family: monospace;
+          font-size: 1rem;
+          background-color: #eee;
+          display: inline-block;
+          padding: .2em .4em;
         }
       `}</style>
       <Component {...pageProps} />

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -7,14 +7,6 @@ class MyDocument extends Document {
     return (
       <Html lang="ja">
         <Head>
-          { /*
-             * Google Fonts を利用する
-             *
-             * - Montserrat
-             * - Noto Sans JP
-             */ }
-          <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@800&family=Noto+Sans+JP:wght@400;700&display=swap" rel="stylesheet" />
-
           { /* gtag / Google Analytics を利用する */}
           {
             GA_TRACKING_ID && <script

--- a/pages/index.js
+++ b/pages/index.js
@@ -21,7 +21,7 @@ export default function Home(props) {
         <div className="home-archive">
           <Link href="/archive/1">アーカイブ</Link>
         </div>
-      ) : ``}
+      ) : null}
 
       <style jsx>{`
         .post-teaser {


### PR DESCRIPTION
Resolve #187

- #187

コミット:

- Issue #187: `@next/font` パッケージを追加。
- Issue #187: Google Fonts フォントの利用に `@next/font` を使う。
- Issue #187: グローバルスタイルを `Layout` から `pages/_app.js` に移動。
